### PR TITLE
feat: add generic Unknown codec value

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -5,6 +5,7 @@ macro_rules! build_codec_enum {
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum Codec {
             $( $var, )*
+            Unknown(u64),
         }
 
         use Codec::*;
@@ -24,7 +25,7 @@ macro_rules! build_codec_enum {
             fn from(codec: Codec) -> u64 {
                 match codec {
                     $( $var => $val, )*
-
+                    Unknown(val) => val,
                 }
             }
         }


### PR DESCRIPTION
I am currently working on a project where we want to use CID to describe our data, and in the long-term also want to open-source it and have a Multicodec code assigned. However in the meantime while we are prototyping it, it would be nice to have the capability to just use a currently unassigned value in place of an assigned value. Other implementations like `js-cid` allow for that by allowing to pass in the raw bytes in addition to specifying a enum-like string.

I'm open to change the name from `Unknown` to something else, if you have a better idea!

Looking forward to some feedback!