### PR TITLE
Add support for `str::parse()`

### DIFF
--- a/src/to_cid.rs
+++ b/src/to_cid.rs
@@ -1,4 +1,5 @@
 use std::io::Cursor;
+use std::str::FromStr;
 use multibase;
 use multihash;
 use integer_encoding::VarIntReader;
@@ -56,6 +57,14 @@ impl ToCid for str {
         }?;
 
         decoded.to_cid()
+    }
+}
+
+
+impl FromStr for Cid {
+    type Err = Error;
+    fn from_str(src: &str) -> Result<Self> {
+        src.to_cid()
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -36,6 +36,15 @@ fn v0_handling() {
 }
 
 #[test]
+fn from_str() {
+    let cid: Cid = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n".parse().unwrap();
+    assert_eq!(cid.version, Version::V0);
+
+    let bad = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII".parse::<Cid>();
+    assert_eq!(bad, Err(Error::ParsingError));
+}
+
+#[test]
 fn v0_error() {
     let bad = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII";
     assert_eq!(Cid::from(bad), Err(Error::ParsingError));


### PR DESCRIPTION
by implementing `std::str::FromStr`