### PR TITLE
Upgrade multibase and multihash to support more encodings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ pre-release-commit-message = "Release {{version}} 🎉🎉"
 no-dev-version = true
 
 [dependencies]
-multihash = "~0.8.0"
-multibase = "~0.6.0"
+multihash = "~0.9.4"
+multibase = "~0.8.0"
 integer-encoding = "~1.0.3"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,8 +44,20 @@ impl From<multibase::Error> for Error {
     }
 }
 
-impl From<multihash::Error> for Error {
-    fn from(_: multihash::Error) -> Error {
+impl From<multihash::EncodeError> for Error {
+    fn from(_: multihash::EncodeError) -> Error {
+        Error::ParsingError
+    }
+}
+
+impl From<multihash::DecodeError> for Error {
+    fn from(_: multihash::DecodeError) -> Error {
+        Error::ParsingError
+    }
+}
+
+impl From<multihash::DecodeOwnedError> for Error {
+    fn from(_: multihash::DecodeOwnedError) -> Error {
         Error::ParsingError
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -18,7 +18,7 @@ impl Version {
     }
 
     pub fn is_v0_str(data: &str) -> bool {
-        // v0 is a base58btc encoded sha hash, so it has
+        // v0 is a Base58Btc encoded sha hash, so it has
         // fixed length and always begins with "Qm"
         data.len() == 46 && data.starts_with("Qm")
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,10 @@
 use cid::{Cid, Codec, Error, Prefix, Version};
 use std::collections::HashMap;
+use std::str::FromStr;
 
 #[test]
 fn basic_marshalling() {
-    let h = multihash::encode(multihash::Hash::SHA2256, b"beep boop").unwrap();
+    let h = multihash::encode(multihash::Hash::SHA2256, b"beep boop").unwrap().into_bytes();
 
     let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
 
@@ -52,7 +53,7 @@ fn v0_error() {
 #[test]
 fn prefix_roundtrip() {
     let data = b"awesome test content";
-    let h = multihash::encode(multihash::Hash::SHA2256, data).unwrap();
+    let h = multihash::encode(multihash::Hash::SHA2256, data).unwrap().into_bytes();
 
     let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
     let prefix = cid.prefix();
@@ -97,4 +98,13 @@ fn test_hash() {
     let cid = Cid::new_from_prefix(&prefix, &data);
     map.insert(cid.clone(), data.clone());
     assert_eq!(&data, map.get(&cid).unwrap());
+}
+
+
+#[test]
+fn test_base32() {
+    let cid = Cid::from_str("bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy").unwrap();
+    assert_eq!(cid.version, Version::V1);
+    assert_eq!(cid.codec, Codec::Raw);
+    assert_eq!(cid.hash, multihash::encode(multihash::Hash::SHA2256, b"foo").unwrap().into_bytes());
 }


### PR DESCRIPTION
This PR currently depends on the unreleased version of `rust-multibase`

Fixes #19