### PR TITLE
refactor cid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ no-dev-version = true
 [dependencies]
 multihash = "0.10"
 multibase = "0.8.0"
-integer-encoding = "1.0.3"
+unsigned-varint = "0.3"

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -52,7 +52,7 @@ impl Cid {
     }
 
     fn to_string_v1(&self) -> String {
-        multibase::encode(Base::Base58Btc, self.to_bytes())
+        multibase::encode(Base::Base32Lower, self.to_bytes())
     }
 
     fn to_bytes_v0(&self) -> Vec<u8> {

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,0 +1,119 @@
+use std::{fmt, hash, str};
+
+use multibase::Base;
+use multihash::MultihashRef;
+use unsigned_varint::encode as varint_encode;
+
+use crate::codec::Codec;
+use crate::error::{Error, Result};
+use crate::prefix::Prefix;
+use crate::to_cid::ToCid;
+use crate::version::Version;
+
+/// Representation of a CID.
+#[derive(Eq, PartialEq, Clone, Debug)]
+pub struct Cid {
+    /// The version of CID.
+    pub version: Version,
+    /// The codec of CID.
+    pub codec: Codec,
+    /// The hash of CID.
+    pub hash: Vec<u8>,
+}
+
+impl Cid {
+    /// Create a new CID.
+    pub fn new(version: Version, codec: Codec, hash: &[u8]) -> Cid {
+        Cid {
+            version,
+            codec,
+            hash: hash.into(),
+        }
+    }
+
+    /// Create a new CID from raw data (binary or multibase encoded string)
+    pub fn from<T: ToCid>(data: T) -> Result<Cid> {
+        data.to_cid()
+    }
+
+    /// Create a new CID from a prefix and some data.
+    pub fn new_from_prefix(prefix: &Prefix, data: &[u8]) -> Cid {
+        let mut hash = prefix.mh_type.hasher().unwrap().digest(data).into_bytes();
+        hash.truncate(prefix.mh_len + 2);
+        Cid {
+            version: prefix.version,
+            codec: prefix.codec,
+            hash,
+        }
+    }
+
+    fn to_string_v0(&self) -> String {
+        Base::Base58Btc.encode(&self.hash)
+    }
+
+    fn to_string_v1(&self) -> String {
+        multibase::encode(Base::Base58Btc, self.to_bytes())
+    }
+
+    fn to_bytes_v0(&self) -> Vec<u8> {
+        self.hash.clone()
+    }
+
+    fn to_bytes_v1(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(16);
+
+        let mut buf = varint_encode::u64_buffer();
+        let version = varint_encode::u64(self.version.into(), &mut buf);
+        res.extend_from_slice(version);
+        let mut buf = varint_encode::u64_buffer();
+        let codec = varint_encode::u64(self.codec.into(), &mut buf);
+        res.extend_from_slice(codec);
+        res.extend_from_slice(&self.hash);
+
+        res
+    }
+
+    /// Convert CID to encoded bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self.version {
+            Version::V0 => self.to_bytes_v0(),
+            Version::V1 => self.to_bytes_v1(),
+        }
+    }
+
+    /// Return the prefix of the CID.
+    pub fn prefix(&self) -> Prefix {
+        // Unwrap is safe, as this should have been validated on creation
+        let mh = MultihashRef::from_slice(&self.hash).unwrap();
+
+        Prefix {
+            version: self.version,
+            codec: self.codec,
+            mh_type: mh.algorithm(),
+            mh_len: mh.digest().len(),
+        }
+    }
+}
+
+impl fmt::Display for Cid {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self.version {
+            Version::V0 => write!(f, "{}", self.to_string_v0()),
+            Version::V1 => write!(f, "{}", self.to_string_v1()),
+        }
+    }
+}
+
+#[allow(clippy::derive_hash_xor_eq)]
+impl hash::Hash for Cid {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) {
+        self.to_bytes().hash(state);
+    }
+}
+
+impl str::FromStr for Cid {
+    type Err = Error;
+    fn from_str(src: &str) -> Result<Self> {
+        src.to_cid()
+    }
+}

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,20 +1,19 @@
-use crate::{Error, Result};
+use crate::error::{Error, Result};
 
 macro_rules! build_codec_enum {
-    {$( $val:expr => $var:ident, )*} => {
+    {$( #[$attr:meta] $code:expr => $codec:ident, )*} => {
+        /// List of types currently supported in the multicodec spec.
         #[derive(PartialEq, Eq, Clone, Copy, Debug)]
         pub enum Codec {
-            $( $var, )*
+            $( #[$attr] $codec, )*
         }
 
-        use Codec::*;
-
         impl Codec {
-            /// Convert a number to the matching codec
+            /// Convert a number to the matching codec, or `Error` if no codec is matching.
             pub fn from(raw: u64) -> Result<Codec> {
                 match raw {
-                    $( $val => Ok($var), )*
-                    _ => Err(Error::UnknownCodec),
+                    $( $code => Ok(Self::$codec), )*
+                    _ => Err(Error::UnknownCodec(raw)),
                 }
             }
         }
@@ -23,8 +22,7 @@ macro_rules! build_codec_enum {
             /// Convert to the matching integer code
             fn from(codec: Codec) -> u64 {
                 match codec {
-                    $( $var => $val, )*
-
+                    $( Codec::$codec => $code, )*
                 }
             }
         }
@@ -32,22 +30,40 @@ macro_rules! build_codec_enum {
 }
 
 build_codec_enum! {
+    /// Raw binary
     0x55 => Raw,
+    /// MerkleDAG protobuf
     0x70 => DagProtobuf,
+    /// MerkleDAG cbor
     0x71 => DagCBOR,
+    /// Raw Git object
     0x78 => GitRaw,
+    /// Ethereum Block (RLP)
     0x90 => EthereumBlock,
+    /// Ethereum Block List (RLP)
     0x91 => EthereumBlockList,
+    /// Ethereum Transaction Trie (Eth-Trie)
     0x92 => EthereumTxTrie,
+    /// Ethereum Transaction (RLP)
     0x93 => EthereumTx,
+    /// Ethereum Transaction Receipt Trie (Eth-Trie)
     0x94 => EthereumTxReceiptTrie,
+    /// Ethereum Transaction Receipt (RLP)
     0x95 => EthereumTxReceipt,
+    /// Ethereum State Trie (Eth-Secure-Trie)
     0x96 => EthereumStateTrie,
+    /// Ethereum Account Snapshot (RLP)
     0x97 => EthereumAccountSnapshot,
+    /// Ethereum Contract Storage Trie (Eth-Secure-Trie)
     0x98 => EthereumStorageTrie,
+    /// Bitcoin Block
     0xb0 => BitcoinBlock,
+    /// Bitcoin Transaction
     0xb1 => BitcoinTx,
+    /// Zcash Block
     0xc0 => ZcashBlock,
+    /// Zcash Transaction
     0xc1 => ZcashTx,
+    /// MerkleDAG json
     0x0129 => DagJSON,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,62 +1,56 @@
-use std::{fmt, io};
+use std::{error, fmt};
 
-pub type Result<T> = ::std::result::Result<T, Error>;
+/// Type alias to use this library's [`Error`] type in a `Result`.
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// Error types
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Error {
-    UnknownCodec,
+    /// Unknown CID codec.
+    UnknownCodec(u64),
+    /// Invalid CID version.
+    InvalidCidVersion(u64),
+    /// Input data is too short.
     InputTooShort,
-    ParsingError,
-    InvalidCidVersion,
+    /// Multibase parsing failure.
+    ParseBaseError,
+    /// Multihash parseing failure.
+    ParseHashError,
+    /// Unsigned varint decode failure.
+    UnsignedVarIntDecodeError,
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::Error::*;
-        let error = match *self {
-            UnknownCodec => "Unknown codec",
-            InputTooShort => "Input too short",
-            ParsingError => "Failed to parse multihash",
-            InvalidCidVersion => "Unrecognized CID version",
-        };
-
-        f.write_str(error)
+        match self {
+            Error::UnknownCodec(codec) => write!(f, "Unknown codec: {}", codec),
+            Error::InvalidCidVersion(version) => write!(f, "Unrecognized CID version: {}", version),
+            Error::InputTooShort => f.write_str("Input too short"),
+            Error::ParseBaseError => f.write_str("Failed to parse multibase"),
+            Error::ParseHashError => f.write_str("Failed to parse multihase"),
+            Error::UnsignedVarIntDecodeError => {
+                f.write_str("Failed to decode unsigned varint format")
+            }
+        }
     }
 }
 
-impl From<io::Error> for Error {
-    fn from(_: io::Error) -> Error {
-        Error::ParsingError
-    }
-}
+impl error::Error for Error {}
 
 impl From<multibase::Error> for Error {
     fn from(_: multibase::Error) -> Error {
-        Error::ParsingError
-    }
-}
-
-impl From<multihash::EncodeError> for Error {
-    fn from(_: multihash::EncodeError) -> Error {
-        Error::ParsingError
+        Error::ParseBaseError
     }
 }
 
 impl From<multihash::DecodeError> for Error {
     fn from(_: multihash::DecodeError) -> Error {
-        Error::ParsingError
+        Error::ParseHashError
     }
 }
 
-impl From<multihash::DecodeOwnedError> for Error {
-    fn from(_: multihash::DecodeOwnedError) -> Error {
-        Error::ParsingError
-    }
-}
-
-impl From<Error> for fmt::Error {
-    fn from(_: Error) -> fmt::Error {
-        fmt::Error {}
+impl From<unsigned_varint::decode::Error> for Error {
+    fn from(_: unsigned_varint::decode::Error) -> Self {
+        Error::UnsignedVarIntDecodeError
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,167 +1,19 @@
+//! # cid
+//!
+//! Implementation of [cid](https://github.com/ipld/cid) in Rust.
+
+#![deny(missing_docs)]
+
+mod cid;
 mod codec;
 mod error;
-/// ! # cid
-/// !
-/// ! Implementation of [cid](https://github.com/ipld/cid) in Rust.
+mod prefix;
 mod to_cid;
 mod version;
 
-pub use codec::Codec;
-pub use error::{Error, Result};
-pub use to_cid::ToCid;
-pub use version::Version;
-
-use integer_encoding::{VarIntReader, VarIntWriter};
-use multihash::Multihash;
-use std::fmt;
-use std::io::Cursor;
-
-/// Representation of a CID.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Cid {
-    pub version: Version,
-    pub codec: Codec,
-    pub hash: Vec<u8>,
-}
-
-/// Prefix represents all metadata of a CID, without the actual content.
-#[derive(PartialEq, Eq, Clone, Debug)]
-pub struct Prefix {
-    pub version: Version,
-    pub codec: Codec,
-    pub mh_type: multihash::Code,
-    pub mh_len: usize,
-}
-
-impl Cid {
-    /// Create a new CID.
-    pub fn new(codec: Codec, version: Version, hash: &[u8]) -> Cid {
-        Cid {
-            version,
-            codec,
-            hash: hash.into(),
-        }
-    }
-
-    /// Create a new CID from raw data (binary or multibase encoded string)
-    pub fn from<T: ToCid>(data: T) -> Result<Cid> {
-        data.to_cid()
-    }
-
-    /// Create a new CID from a prefix and some data.
-    pub fn new_from_prefix(prefix: &Prefix, data: &[u8]) -> Cid {
-        let mut hash = prefix.mh_type.hasher().unwrap().digest(data).into_bytes();
-        hash.truncate(prefix.mh_len + 2);
-        Cid {
-            version: prefix.version,
-            codec: prefix.codec.to_owned(),
-            hash,
-        }
-    }
-
-    fn to_string_v0(&self) -> String {
-        use multibase::{encode, Base};
-
-        let mut string = encode(Base::Base58Btc, self.hash.as_slice());
-
-        // Drop the first character as v0 does not know
-        // about multibase
-        string.remove(0);
-
-        string
-    }
-
-    fn to_string_v1(&self) -> String {
-        use multibase::{encode, Base};
-
-        encode(Base::Base58Btc, self.to_bytes().as_slice())
-    }
-
-    fn to_bytes_v0(&self) -> Vec<u8> {
-        self.hash.clone()
-    }
-
-    fn to_bytes_v1(&self) -> Vec<u8> {
-        let mut res = Vec::with_capacity(16);
-        res.write_varint(u64::from(self.version)).unwrap();
-        res.write_varint(u64::from(self.codec)).unwrap();
-        res.extend_from_slice(&self.hash);
-
-        res
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        match self.version {
-            Version::V0 => self.to_bytes_v0(),
-            Version::V1 => self.to_bytes_v1(),
-        }
-    }
-
-    pub fn prefix(&self) -> Prefix {
-        // Unwrap is safe, as this should have been validated on creation
-        let mh = Multihash::from_bytes(Vec::from(self.hash.as_slice())).unwrap();
-
-        Prefix {
-            version: self.version,
-            codec: self.codec.to_owned(),
-            mh_type: mh.algorithm(),
-            mh_len: mh.digest().len(),
-        }
-    }
-}
-
-#[allow(clippy::derive_hash_xor_eq)]
-impl std::hash::Hash for Cid {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.to_bytes().hash(state);
-    }
-}
-
-impl fmt::Display for Cid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let output = match self.version {
-            Version::V0 => self.to_string_v0(),
-            Version::V1 => self.to_string_v1(),
-        };
-        write!(f, "{}", output)
-    }
-}
-
-impl Prefix {
-    pub fn new_from_bytes(data: &[u8]) -> Result<Prefix> {
-        let mut cur = Cursor::new(data);
-
-        let raw_version = cur.read_varint()?;
-        let raw_codec = cur.read_varint()?;
-        let raw_mh_type: u64 = cur.read_varint()?;
-
-        let version = Version::from(raw_version)?;
-        let codec = Codec::from(raw_codec)?;
-
-        let mh_type = match multihash::Code::from_u64(raw_mh_type) {
-            multihash::Code::Custom(_) => Err(Error::UnknownCodec),
-            code => Ok(code),
-        }?;
-
-        let mh_len = cur.read_varint()?;
-
-        Ok(Prefix {
-            version,
-            codec,
-            mh_type,
-            mh_len,
-        })
-    }
-
-    pub fn as_bytes(&self) -> Vec<u8> {
-        let mut res = Vec::with_capacity(4);
-
-        // io can't fail on Vec
-        res.write_varint(u64::from(self.version)).unwrap();
-        res.write_varint(u64::from(self.codec)).unwrap();
-        res.write_varint(self.mh_type.to_u64()).unwrap();
-        res.write_varint(self.mh_len as u64).unwrap();
-
-        res
-    }
-}
+pub use self::cid::Cid;
+pub use self::codec::Codec;
+pub use self::error::{Error, Result};
+pub use self::prefix::Prefix;
+pub use self::to_cid::ToCid;
+pub use self::version::Version;

--- a/src/prefix.rs
+++ b/src/prefix.rs
@@ -1,0 +1,64 @@
+use unsigned_varint::{decode as varint_decode, encode as varint_encode};
+
+use crate::codec::Codec;
+use crate::error::{Error, Result};
+use crate::version::Version;
+
+/// Prefix represents all metadata of a CID, without the actual content.
+#[derive(PartialEq, Eq, Clone, Debug)]
+pub struct Prefix {
+    /// The version of CID.
+    pub version: Version,
+    /// The codec of CID.
+    pub codec: Codec,
+    /// The multihash type of CID.
+    pub mh_type: multihash::Code,
+    /// The multihash length of CID.
+    pub mh_len: usize,
+}
+
+impl Prefix {
+    /// Create a new prefix from encoded bytes.
+    pub fn new_from_bytes(data: &[u8]) -> Result<Prefix> {
+        let (raw_version, remain) = varint_decode::u64(data)?;
+        let version = Version::from(raw_version)?;
+
+        let (raw_codec, remain) = varint_decode::u64(remain)?;
+        let codec = Codec::from(raw_codec)?;
+
+        let (raw_mh_type, remain) = varint_decode::u64(remain)?;
+        let mh_type = match multihash::Code::from_u64(raw_mh_type) {
+            multihash::Code::Custom(code) => return Err(Error::UnknownCodec(code)),
+            code => code,
+        };
+
+        let mh_len = varint_decode::usize(remain)?.0;
+
+        Ok(Prefix {
+            version,
+            codec,
+            mh_type,
+            mh_len,
+        })
+    }
+
+    /// Convert the prefix to encoded bytes.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(4);
+
+        let mut buf = varint_encode::u64_buffer();
+        let encoded = varint_encode::u64(self.version.into(), &mut buf);
+        res.extend_from_slice(encoded);
+        let mut buf = varint_encode::u64_buffer();
+        let encoded = varint_encode::u64(self.codec.into(), &mut buf);
+        res.extend_from_slice(encoded);
+        let mut buf = varint_encode::u64_buffer();
+        let encoded = varint_encode::u64(self.mh_type.to_u64(), &mut buf);
+        res.extend_from_slice(encoded);
+        let mut buf = varint_encode::u64_buffer();
+        let encoded = varint_encode::u64(self.mh_len as u64, &mut buf);
+        res.extend_from_slice(encoded);
+
+        res
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,28 +1,32 @@
 use crate::{Error, Result};
 
+/// The version of the CID.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub enum Version {
+    /// CID version 0.
     V0,
+    /// CID version 1.
     V1,
 }
 
-use Version::*;
-
 impl Version {
+    /// Convert a number to the matching version, or `Error` if no valid version is matching.
     pub fn from(raw: u64) -> Result<Version> {
         match raw {
-            0 => Ok(V0),
-            1 => Ok(V1),
-            _ => Err(Error::InvalidCidVersion),
+            0 => Ok(Version::V0),
+            1 => Ok(Version::V1),
+            _ => Err(Error::InvalidCidVersion(raw)),
         }
     }
 
+    /// Check if the version of `data` string is CIDv0.
     pub fn is_v0_str(data: &str) -> bool {
         // v0 is a Base58Btc encoded sha hash, so it has
         // fixed length and always begins with "Qm"
         data.len() == 46 && data.starts_with("Qm")
     }
 
+    /// Check if the version of `data` bytes is CIDv0.
     pub fn is_v0_binary(data: &[u8]) -> bool {
         data.len() == 34 && data.starts_with(&[0x12, 0x20])
     }
@@ -31,8 +35,8 @@ impl Version {
 impl From<Version> for u64 {
     fn from(ver: Version) -> u64 {
         match ver {
-            V0 => 0,
-            V1 => 1,
+            Version::V0 => 0,
+            Version::V1 => 1,
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,13 +1,14 @@
-use cid::{Cid, Codec, Error, Prefix, Version};
-use multihash::Sha2_256;
 use std::collections::HashMap;
 use std::str::FromStr;
+
+use cid::{Cid, Codec, Error, Prefix, Version};
+use multihash::Sha2_256;
 
 #[test]
 fn basic_marshalling() {
     let h = Sha2_256::digest(b"beep boop").into_bytes();
 
-    let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
+    let cid = Cid::new(Version::V1, Codec::DagProtobuf, &h);
 
     let data = cid.to_bytes();
     let out = Cid::from(data).unwrap();
@@ -42,13 +43,13 @@ fn from_str() {
     assert_eq!(cid.version, Version::V0);
 
     let bad = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII".parse::<Cid>();
-    assert_eq!(bad, Err(Error::ParsingError));
+    assert_eq!(bad, Err(Error::ParseBaseError));
 }
 
 #[test]
 fn v0_error() {
     let bad = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zIII";
-    assert_eq!(Cid::from(bad), Err(Error::ParsingError));
+    assert_eq!(Cid::from(bad), Err(Error::ParseBaseError));
 }
 
 #[test]
@@ -56,7 +57,7 @@ fn prefix_roundtrip() {
     let data = b"awesome test content";
     let h = Sha2_256::digest(data).into_bytes();
 
-    let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
+    let cid = Cid::new(Version::V1, Codec::DagProtobuf, &h);
     let prefix = cid.prefix();
 
     let cid2 = Cid::new_from_prefix(&prefix, data);


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* ~~Move `Cid` and `Prefix` structure to their files of the same name.~~
* ~~`Cid::new(codec, version, hash)` => `Cid::new(version, codec, hash)` (More intuitive)~~
* ~~Use `unsigned-varint` instead of `integer-encoding` (Reduce dependency)~~
* ~~Use `MultihashRef::from_slice` instead of `Multihash::from_bytes` (Improve performance)~~
* ~~Improve `Cid::to_string_v0` and `impl ToCid for str` (Improve performance for Cid with version 0)~~
* ~~Fix `to_string_v1` of `Cid` (see [golang version](https://github.com/ipfs/go-cid/blob/72cd3d39d7fe1b2ab7abac0854a1bcb046a8d009/cid.go#L347))~~