### PR TITLE
chore: doc uploading isn't a thing anymore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ readme = "README.md"
 edition = "2018"
 
 [package.metadata.release]
-upload-doc = true
 pre-release-commit-message = "Release {{version}} 🎉🎉"
 no-dev-version = true
 


### PR DESCRIPTION
The cargo-release crate did remove the docs update functionality
https://github.com/sunng87/cargo-release/commit/86429c581efee8177986bb5355c37c3c180b8ef8#diff-3abe220864dd3f76354817756e6ca3dc