### PR TITLE
Use multihash instance to store the hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ use multihash;
 fn main() {
     let h = multihash::Sha2_256::digest(b"beep boop");
 
-    let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
+    let cid = Cid::new(Codec::DagProtobuf, Version::V1, h);
 
     let data = cid.to_bytes();
     let out = Cid::from(data).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ impl Cid {
     fn to_string_v0(&self) -> String {
         use multibase::{encode, Base};
 
-        let mut string = encode(Base::Base58Btc, self.hash.to_vec());
+        let mut string = encode(Base::Base58Btc, self.hash.as_bytes());
 
         // Drop the first character as v0 does not know
         // about multibase

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,11 +35,11 @@ pub struct Prefix {
 
 impl Cid {
     /// Create a new CID.
-    pub fn new(codec: Codec, version: Version, hash: &[u8]) -> Cid {
+    pub fn new(codec: Codec, version: Version, hash: Multihash) -> Cid {
         Cid {
             version,
             codec,
-            hash: Multihash::from_bytes(hash.into()).unwrap(),
+            hash,
         }
     }
 

--- a/src/to_cid.rs
+++ b/src/to_cid.rs
@@ -1,5 +1,5 @@
 use integer_encoding::VarIntReader;
-use multihash::{self, Multihash};
+use multihash::{self, MultihashRef};
 use std::io::Cursor;
 use std::str::FromStr;
 
@@ -77,7 +77,7 @@ impl ToCid for [u8] {
     /// Create a Cid from a byte slice.
     fn to_cid(&self) -> Result<Cid> {
         if Version::is_v0_binary(self) {
-            let mh = Multihash::from_bytes(Vec::from(self))?;
+            let mh = MultihashRef::from_slice(self)?.to_owned();
             Ok(Cid::new(Codec::DagProtobuf, Version::V0, mh))
         } else {
             let mut cur = Cursor::new(self);
@@ -89,7 +89,7 @@ impl ToCid for [u8] {
 
             let hash = &self[cur.position() as usize..];
 
-            let mh = Multihash::from_bytes(Vec::from(hash))?;
+            let mh = MultihashRef::from_slice(hash)?.to_owned();
 
             Ok(Cid::new(codec, version, mh))
         }

--- a/src/to_cid.rs
+++ b/src/to_cid.rs
@@ -77,9 +77,8 @@ impl ToCid for [u8] {
     /// Create a Cid from a byte slice.
     fn to_cid(&self) -> Result<Cid> {
         if Version::is_v0_binary(self) {
-            // Verify that hash can be decoded, this is very cheap
-            let _mh = Multihash::from_bytes(Vec::from(self))?;
-            Ok(Cid::new(Codec::DagProtobuf, Version::V0, self))
+            let mh = Multihash::from_bytes(Vec::from(self))?;
+            Ok(Cid::new(Codec::DagProtobuf, Version::V0, mh))
         } else {
             let mut cur = Cursor::new(self);
             let raw_version = cur.read_varint()?;
@@ -90,10 +89,9 @@ impl ToCid for [u8] {
 
             let hash = &self[cur.position() as usize..];
 
-            // Verify that hash can be decoded, this is very cheap
-            let _mh = Multihash::from_bytes(Vec::from(hash))?;
+            let mh = Multihash::from_bytes(Vec::from(hash))?;
 
-            Ok(Cid::new(codec, version, hash))
+            Ok(Cid::new(codec, version, mh))
         }
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -5,9 +5,9 @@ use std::str::FromStr;
 
 #[test]
 fn basic_marshalling() {
-    let h = Sha2_256::digest(b"beep boop").into_bytes();
+    let h = Sha2_256::digest(b"beep boop");
 
-    let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
+    let cid = Cid::new(Codec::DagProtobuf, Version::V1, h);
 
     let data = cid.to_bytes();
     let out = Cid::from(data).unwrap();
@@ -54,9 +54,9 @@ fn v0_error() {
 #[test]
 fn prefix_roundtrip() {
     let data = b"awesome test content";
-    let h = Sha2_256::digest(data).into_bytes();
+    let h = Sha2_256::digest(data);
 
-    let cid = Cid::new(Codec::DagProtobuf, Version::V1, &h);
+    let cid = Cid::new(Codec::DagProtobuf, Version::V1, h);
     let prefix = cid.prefix();
 
     let cid2 = Cid::new_from_prefix(&prefix, data);

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -106,5 +106,5 @@ fn test_base32() {
     let cid = Cid::from_str("bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy").unwrap();
     assert_eq!(cid.version, Version::V1);
     assert_eq!(cid.codec, Codec::Raw);
-    assert_eq!(cid.hash, Sha2_256::digest(b"foo").into_bytes());
+    assert_eq!(cid.hash, Sha2_256::digest(b"foo"));
 }


### PR DESCRIPTION
...to benefit from inline storage, among other things

With this change, cloning a typical cid containing e.g. a 256 bit hash will not allocate and will therefore be much faster than before.

This also ensures that it is no longer possible to create a cid that contains an invalid multihash, where before you could pass just any byte array via the new method.