### PR TITLE
feat: introduce dedicated methods for creating v0 and v1 CIDs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,10 @@ pub enum Error {
     ParsingError,
     /// Invalid CID version.
     InvalidCidVersion,
+    /// Invalid CIDv0 codec.
+    InvalidCidV0Codec,
+    /// Invalid CIDv0 multihash.
+    InvalidCidV0Multihash,
     /// Varint decode failure.
     VarIntDecodeError,
 }
@@ -28,6 +32,8 @@ impl fmt::Display for Error {
             InputTooShort => "Input too short",
             ParsingError => "Failed to parse multihash",
             InvalidCidVersion => "Unrecognized CID version",
+            InvalidCidV0Codec => "CIDv0 requires a DagPB codec",
+            InvalidCidV0Multihash => "CIDv0 requires a Sha-256 multihash",
             VarIntDecodeError => "Failed to decode unsigned varint format",
         };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -9,7 +9,7 @@ use multihash::Sha2_256;
 fn basic_marshalling() {
     let h = Sha2_256::digest(b"beep boop");
 
-    let cid = Cid::new(Version::V1, Codec::DagProtobuf, h);
+    let cid = Cid::new_v1(Codec::DagProtobuf, h);
 
     let data = cid.to_bytes();
     let out = Cid::try_from(data.clone()).unwrap();
@@ -62,7 +62,7 @@ fn prefix_roundtrip() {
     let data = b"awesome test content";
     let h = Sha2_256::digest(data);
 
-    let cid = Cid::new(Version::V1, Codec::DagProtobuf, h);
+    let cid = Cid::new_v1(Codec::DagProtobuf, h);
     let prefix = cid.prefix();
 
     let cid2 = Cid::new_from_prefix(&prefix, data);


### PR DESCRIPTION
It is now possible to create v0 CIDs via `Cid::new_v0()` and
v1 CIDs via `Cid:new_v0()`.

Credit goes to @dvc94ch as this code is based on
https://github.com/multiformats/rust-cid/pull/18