### PR TITLE
`Cid::new` doesn't seem to need to a cid::Version

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -43,15 +43,10 @@ impl Cid {
     }
 
     /// Create a new CID.
-    pub fn new(version: Version, codec: Codec, hash: Multihash) -> Result<Cid> {
-        match version {
-            Version::V0 => {
-                if codec != Codec::DagProtobuf {
-                    return Err(Error::InvalidCidV0Codec);
-                }
-                Self::new_v0(hash)
-            }
-            Version::V1 => Ok(Self::new_v1(codec, hash)),
+    pub fn new(codec: Codec, hash: Multihash) -> Result<Cid> {
+        match codec {
+            Codec::DagProtobuf => Self::new_v0(hash),
+            _ => Ok(Self::new_v1(codec, hash)),
         }
     }
 


### PR DESCRIPTION
Given that there are now dedicated v0 and v1 constructor functions, it seems redundant to require a `cid::Version` in `Cid::new()` since `cid::Codec` implies a `cid::Version`.