### PR TITLE
fix: do not hash anything within this crate

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -55,12 +55,15 @@ impl Cid {
         }
     }
 
-    /// Create a new CID from a prefix and some data.
-    pub fn new_from_prefix(prefix: &Prefix, data: &[u8]) -> Cid {
-        let mut hash = prefix.mh_type.hasher().unwrap().digest(data);
-        if prefix.mh_len < hash.digest().len() {
-            hash = multihash::wrap(hash.algorithm(), &hash.digest()[..prefix.mh_len]);
+    /// Create a new CID from a prefix and a hash.
+    pub fn new_from_prefix(prefix: &Prefix, digest: &[u8]) -> Cid {
+        let hash = if digest.len() <= prefix.mh_len {
+            multihash::wrap(prefix.mh_type, &digest)
         }
+        // Trim the digest if it is bigger than the given length
+        else {
+            multihash::wrap(prefix.mh_type, &digest[..prefix.mh_len])
+        };
         Cid {
             version: prefix.version,
             codec: prefix.codec,


### PR DESCRIPTION
`new_from_prefix()` is the only function that does hashing of the data.
For a clear separation of concerns, it is changed to take a hash instead.
The hashing should be done before a CID is created.

BREAKING CHANGE: `new_from_prefix()` takes a hash intead of data

Prior to this change `new_from_prefix()` took some data that needs to
be hashed as input. With this change, you need to hash the data before
this call and then pass the hash digest in.

---

I'd like to start a discussion about this. With this change, the `new_from_prefix()` is even less useful. Hence I would even prefer removing the whole story about prefixes completely. I find it only useful in the light of Bitswap. What about moving it from here directly  into [Bitswap](https://github.com/ipfs-rust/rust-ipfs/tree/6cbf679644fea7065566e5becade311d1ec66ebf/bitswap)?

/cc @dvc94ch @koivunej