### PR TITLE
fix: move to released versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ pre-release-commit-message = "Release {{version}} 🎉🎉"
 no-dev-version = true
 
 [dependencies]
-multihash = "0.10.1"
+multihash = "0.11"
 multibase = "0.8.0"
 unsigned-varint = "0.3"
 
@@ -24,10 +24,7 @@ rand = { version = "0.7.3", optional = true }
 [dev-dependencies]
 quickcheck = "0.9.2"
 rand = "0.7.3"
-multihash = { version = "0.10.1", features = ["test"] }
+multihash = { version = "0.11", features = ["test"] }
 
 [features]
 test = ["quickcheck", "rand"]
-
-[patch.crates-io]
-multihash = { git = "https://github.com/multiformats/rust-multihash", branch = "master" }


### PR DESCRIPTION
The previous PR shouldn't have been merged before multihash isn't released.
This commit fixes it.