### PR TITLE
feat: make base encoding to other bases possible

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use multibase::Base;
+use multibase::{encode as base_encode, Base};
 use multihash::{Code, MultihashGeneric, MultihashRefGeneric};
 use unsigned_varint::{decode as varint_decode, encode as varint_encode};
 
@@ -114,6 +114,32 @@ where
         match self.version {
             Version::V0 => self.to_bytes_v0(),
             Version::V1 => self.to_bytes_v1(),
+        }
+    }
+
+    /// Convert CID into a multibase encoded string
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use cid::{Cid, Codec};
+    /// use multibase::Base;
+    /// use multihash::Sha2_256;
+    ///
+    /// let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(b"foo"));
+    /// let encoded = cid.to_string_of_base(Base::Base64).unwrap();
+    /// assert_eq!(encoded, "mAVUSICwmtGto/8aP+ZtFPB0wQTQTQi1wZIO/oPmKXohiZueu");
+    /// ```
+    pub fn to_string_of_base(&self, base: Base) -> Result<String> {
+        match self.version {
+            Version::V0 => {
+                if base == Base::Base58Btc {
+                    Ok(self.to_string_v0())
+                } else {
+                    Err(Error::InvalidCidV0Base)
+                }
+            }
+            Version::V1 => Ok(base_encode(base, self.to_bytes())),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,6 +18,8 @@ pub enum Error {
     InvalidCidV0Codec,
     /// Invalid CIDv0 multihash.
     InvalidCidV0Multihash,
+    /// Invalid CIDv0 base encoding.
+    InvalidCidV0Base,
     /// Varint decode failure.
     VarIntDecodeError,
 }
@@ -34,6 +36,7 @@ impl fmt::Display for Error {
             InvalidCidVersion => "Unrecognized CID version",
             InvalidCidV0Codec => "CIDv0 requires a DagPB codec",
             InvalidCidV0Multihash => "CIDv0 requires a Sha-256 multihash",
+            InvalidCidV0Base => "CIDv0 requires a Base58 base",
             VarIntDecodeError => "Failed to decode unsigned varint format",
         };
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -3,6 +3,7 @@ use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
 use cid::{Cid, Codec, Error, Version};
+use multibase::Base;
 use multihash::Sha2_256;
 
 #[test]
@@ -90,4 +91,47 @@ fn test_base32() {
     assert_eq!(cid.version(), Version::V1);
     assert_eq!(cid.codec(), Codec::Raw);
     assert_eq!(cid.hash(), Sha2_256::digest(b"foo"));
+}
+
+#[test]
+fn to_string() {
+    let expected_cid = "bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy";
+    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(b"foo"));
+    assert_eq!(cid.to_string(), expected_cid);
+}
+
+#[test]
+fn to_string_of_base32() {
+    let expected_cid = "bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy";
+    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(b"foo"));
+    assert_eq!(
+        cid.to_string_of_base(Base::Base32Lower).unwrap(),
+        expected_cid
+    );
+}
+
+#[test]
+fn to_string_of_base64() {
+    let expected_cid = "mAVUSICwmtGto/8aP+ZtFPB0wQTQTQi1wZIO/oPmKXohiZueu";
+    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(b"foo"));
+    assert_eq!(cid.to_string_of_base(Base::Base64).unwrap(), expected_cid);
+}
+
+#[test]
+fn to_string_of_base58_v0() {
+    let expected_cid = "QmRJzsvyCQyizr73Gmms8ZRtvNxmgqumxc2KUp71dfEmoj";
+    let cid = Cid::new_v0(Sha2_256::digest(b"foo")).unwrap();
+    assert_eq!(
+        cid.to_string_of_base(Base::Base58Btc).unwrap(),
+        expected_cid
+    );
+}
+
+#[test]
+fn to_string_of_base_v0_error() {
+    let cid = Cid::new_v0(Sha2_256::digest(b"foo")).unwrap();
+    assert_eq!(
+        cid.to_string_of_base(Base::Base16Upper),
+        Err(Error::InvalidCidV0Base)
+    );
 }


### PR DESCRIPTION
Introduce `string_of_base()` method which enables the CID to be encoded
at different base encodings.

Example:

    use cid::{Cid, Codec};
    use multibase::Base;
    use multihash::Sha2_256;

    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(b"foo"));
    let encoded = cid.to_string_of_base(Base::Base64).unwrap();
    assert_eq!(encoded, "mAVUSICwmtGto/8aP+ZtFPB0wQTQTQi1wZIO/oPmKXohiZueu");