### PR TITLE
chore: use latest version of Tarpaulin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.11.0'
           args: '-- --test-threads 1'
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v1.0.6
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
Always use the latest version of Tarpaulin for creating the coverage
report.