### PR TITLE
feat: make library no_std compatible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,3 +61,25 @@ jobs:
 
       - name: Upload to codecov.io
         uses: codecov/codecov-action@v1
+
+  no_std:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Install cargo-nono
+        uses: actions-rs/install@master
+        with:
+          crate: cargo-nono
+
+      - name: Check no_std without default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: nono
+          args: check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,20 @@ edition = "2018"
 pre-release-commit-message = "Release {{version}} 🎉🎉"
 no-dev-version = true
 
-[dependencies]
-multihash = "0.12"
-multibase = "0.8.0"
-unsigned-varint = "0.5.0"
+[features]
+default = ["std"]
+std = ["multibase", "multihash/std", "unsigned-varint/std"]
+arb = ["quickcheck", "rand", "multihash/arb"]
 
+[dependencies]
+multihash = { version = "0.12", default-features = false }
+unsigned-varint = { version = "0.5.1", default-features = false }
+
+multibase = { version = "0.8.0", optional = true }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9.2"
 rand = "0.7.3"
-multihash = { version = "0.12", features = ["arb"] }
-
-[features]
-test = ["quickcheck", "rand"]
+multihash = { version = "0.12", default-features = false, features = ["arb", "multihash-impl"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,7 @@
-use std::{error, fmt};
+use core::fmt;
 
 /// Type alias to use this library's [`Error`] type in a `Result`.
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = core::result::Result<T, Error>;
 
 /// Error types
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
@@ -24,7 +24,8 @@ pub enum Error {
     VarIntDecodeError,
 }
 
-impl error::Error for Error {}
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
@@ -44,6 +45,7 @@ impl fmt::Display for Error {
     }
 }
 
+#[cfg(feature = "std")]
 impl From<multibase::Error> for Error {
     fn from(_: multibase::Error) -> Error {
         Error::ParsingError

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,17 +3,19 @@
 //! Implementation of [cid](https://github.com/ipld/cid) in Rust.
 
 #![deny(missing_docs)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod cid;
 mod error;
 mod version;
 
-#[cfg(any(test, feature = "test"))]
+#[cfg(any(test, feature = "arb"))]
 mod arb;
 
 pub use self::error::{Error, Result};
 pub use self::version::Version;
 
+#[cfg(feature = "std")]
 pub use multibase;
 pub use multihash;
 pub use multihash::{Size, U64};

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,4 @@
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use crate::error::{Error, Result};
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -85,7 +85,7 @@ fn test_hash() {
     let hash = Code::Sha2_256.digest(&data);
     let mut map = HashMap::new();
     let cid = Cid::new_v0(hash).unwrap();
-    map.insert(cid.clone(), data.clone());
+    map.insert(cid, data.clone());
     assert_eq!(&data, map.get(&cid).unwrap());
 }
 


### PR DESCRIPTION
It's now possible to use rust-cid with `no_std`.

This commit is based on @dvc94ch's work at
https://github.com/ipfs-rust/tiny-cid

The GitHub action for checkout no_std is based on
@svartalf's work at
https://github.com/svartalf/rust-macaddr/blob/0e89981f2fef6c5a431d38feff887a2762b104de/.github/workflows/ci.yml#L57-L81

BREAKING CHANGE: The `test` feature is now called `arb`.