### PR TITLE
Changes for feature parity with tiny-cid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ pre-release-commit-message = "Release {{version}} 🎉🎉"
 no-dev-version = true
 
 [features]
-default = ["std"]
+default = ["std", "multihash/default"]
 std = ["multibase", "multihash/std", "unsigned-varint/std"]
 arb = ["quickcheck", "rand", "multihash/arb"]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,16 +17,21 @@ no-dev-version = true
 default = ["std"]
 std = ["multibase", "multihash/std", "unsigned-varint/std"]
 arb = ["quickcheck", "rand", "multihash/arb"]
+scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
+serde-codec = ["serde", "multihash/serde-codec"]
 
 [dependencies]
 multihash = { version = "0.12", default-features = false }
 unsigned-varint = { version = "0.5.1", default-features = false }
 
 multibase = { version = "0.8.0", optional = true }
+parity-scale-codec = { version = "1.3.5", optional = true, default-features = false, features = ["derive"] }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
+serde = { version = "1.0.116", optional = true }
 
 [dev-dependencies]
 quickcheck = "0.9.2"
 rand = "0.7.3"
 multihash = { version = "0.12", default-features = false, features = ["arb", "multihash-impl"] }
+serde_json = "1.0.59"

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -291,3 +291,17 @@ impl<S: Size> From<Cid<S>> for String {
         cid.to_string()
     }
 }
+
+#[cfg(feature = "std")]
+impl<'a, S: Size> From<Cid<S>> for std::borrow::Cow<'a, Cid<S>> {
+    fn from(from: Cid<S>) -> Self {
+        std::borrow::Cow::Owned(from)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, S: Size> From<&'a Cid<S>> for std::borrow::Cow<'a, Cid<S>> {
+    fn from(from: &'a Cid<S>) -> Self {
+        std::borrow::Cow::Borrowed(from)
+    }
+}

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -177,6 +177,16 @@ impl<S: Size> Cid<S> {
     }
 }
 
+impl<S: Size> Default for Cid<S> {
+    fn default() -> Self {
+        Self {
+            version: Version::V1,
+            codec: 0,
+            hash: Multihash::<S>::default(),
+        }
+    }
+}
+
 #[cfg(feature = "std")]
 #[allow(clippy::derive_hash_xor_eq)]
 impl<S: Size> std::hash::Hash for Cid<S> {

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,6 +4,10 @@ use crate::error::{Error, Result};
 
 /// The version of the CID.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
+#[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
+#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
+#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
 pub enum Version {
     /// CID version 0.
     V0,


### PR DESCRIPTION
This PR is a collection of small changes (each commit is self-contained), which gets rust-cid to full feature parity with [tiny-cid](https://github.com/ipfs-rust/tiny-cid/). 