### PR TITLE
Upgrade to multihash 0.13

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["serde", "multihash/serde-codec"]
 
 [dependencies]
-multihash = { version = "0.12", default-features = false }
+multihash = { version = "0.13", default-features = false }
 unsigned-varint = { version = "0.5.1", default-features = false }
 
 multibase = { version = "0.8.0", optional = true }
@@ -31,7 +31,7 @@ rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.116", optional = true }
 
 [dev-dependencies]
+multihash = { version = "0.13", default-features = false, features = ["arb"] }
 quickcheck = "0.9.2"
 rand = "0.7.3"
-multihash = { version = "0.12", default-features = false, features = ["arb", "multihash-impl"] }
 serde_json = "1.0.59"

--- a/src/arb.rs
+++ b/src/arb.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use multihash::{Code, Multihash, MultihashDigest, U64};
+use multihash::{Code, Multihash, MultihashDigest};
 use quickcheck::{Arbitrary, Gen};
 use rand::{
     distributions::{weighted::WeightedIndex, Distribution},
@@ -40,7 +40,7 @@ impl Arbitrary for Cid {
                 _ => unreachable!(),
             };
 
-            let hash: Multihash<U64> = Arbitrary::arbitrary(g);
+            let hash: Multihash = Arbitrary::arbitrary(g);
             Cid::new_v1(codec, hash)
         }
     }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -10,7 +10,7 @@ use std::convert::TryFrom;
 
 #[cfg(feature = "std")]
 use multibase::{encode as base_encode, Base};
-use multihash::{Multihash, Size};
+use multihash::{MultihashGeneric as Multihash, Size};
 #[cfg(feature = "std")]
 use unsigned_varint::{encode as varint_encode, io::read_u64 as varint_read_u64};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,24 +5,24 @@
 #![deny(missing_docs)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-pub mod cid;
+mod cid;
 mod error;
 mod version;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;
 
+pub use self::cid::Cid as CidGeneric;
 pub use self::error::{Error, Result};
 pub use self::version::Version;
 
 #[cfg(feature = "std")]
 pub use multibase;
 pub use multihash;
-pub use multihash::{Size, U64};
 
 /// A Cid that contains a multihash with an allocated size of 512 bits.
 ///
 /// This is the same digest size the default multihash code table has.
 ///
-/// If you need a CID that is generic over its digest size, use [`cid::Cid`] instead.
-pub type Cid = self::cid::Cid<U64>;
+/// If you need a CID that is generic over its digest size, use [`CidGeneric`] instead.
+pub type Cid = CidGeneric<multihash::U64>;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,10 +2,10 @@ use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
-use cid::{Cid, Error, Size, Version};
+use cid::{Cid, CidGeneric, Error, Version};
 use multibase::Base;
 use multihash::typenum::U128;
-use multihash::{derive::Multihash, Code, MultihashDigest};
+use multihash::{derive::Multihash, Code, MultihashDigest, Size};
 
 const RAW: u64 = 0x55;
 const DAG_PB: u64 = 0x70;
@@ -140,7 +140,7 @@ fn to_string_of_base_v0_error() {
     ));
 }
 
-fn a_function_that_takes_a_generic_cid<S: Size>(cid: &cid::cid::Cid<S>) -> String {
+fn a_function_that_takes_a_generic_cid<S: Size>(cid: &CidGeneric<S>) -> String {
     cid.to_string()
 }
 
@@ -156,7 +156,7 @@ fn method_can_take_differently_sized_cids() {
     }
 
     let cid_default = Cid::new_v1(RAW, Code::Sha2_256.digest(b"foo"));
-    let cid_128 = cid::cid::Cid::<U128>::new_v1(RAW, Code128::Sha2_256.digest(b"foo"));
+    let cid_128 = CidGeneric::<U128>::new_v1(RAW, Code128::Sha2_256.digest(b"foo"));
 
     assert_eq!(
         a_function_that_takes_a_generic_cid(&cid_default),


### PR DESCRIPTION
This PR upgrades to the latest version of `multihash` 0.13 and makes the `cid` API more similar with exporting `Cid` with a fixed size and `CidGeneric` which is generic over its size.