### PR TITLE
feat: auto derive Hash impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["serde", "multihash/serde-codec"]
 
 [dependencies]
-multihash = { version = "0.13", default-features = false }
+multihash = { version = "0.13.1", default-features = false }
 unsigned-varint = { version = "0.5.1", default-features = false }
 
 multibase = { version = "0.8.0", optional = true }
@@ -31,7 +31,7 @@ rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.116", optional = true }
 
 [dev-dependencies]
-multihash = { version = "0.13", default-features = false, features = ["arb"] }
+multihash = { version = "0.13.1", default-features = false, features = ["arb"] }
 quickcheck = "0.9.2"
 rand = "0.7.3"
 serde_json = "1.0.59"

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -25,7 +25,7 @@ const SHA2_256: u64 = 0x12;
 /// Representation of a CID.
 ///
 /// The generic is about the allocated size of the multihash.
-#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord)]
+#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
 #[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
@@ -189,14 +189,6 @@ impl<S: Size> Default for Cid<S> {
             codec: 0,
             hash: Multihash::<S>::default(),
         }
-    }
-}
-
-#[cfg(feature = "std")]
-#[allow(clippy::derive_hash_xor_eq)]
-impl<S: Size> std::hash::Hash for Cid<S> {
-    fn hash<T: std::hash::Hasher>(&self, state: &mut T) {
-        self.to_bytes().hash(state);
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -3,7 +3,7 @@ use core::convert::TryFrom;
 use crate::error::{Error, Result};
 
 /// The version of the CID.
-#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
 #[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]


### PR DESCRIPTION
This makes the `Hash` implementation of `Cid` no_std compatible.

BREAKING CHANGE: the hash is different from previous versions.