### PR TITLE
Add manual debug instance

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -348,4 +348,24 @@ mod tests {
         let cid2 = serde_json::from_str(&bytes).unwrap();
         assert_eq!(cid, cid2);
     }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_debug_instance() {
+        use super::Cid;
+        use multihash::U64;
+        use std::str::FromStr;
+        let cid =
+            Cid::<U64>::from_str("bafyreibjo4xmgaevkgud7mbifn3dzp4v4lyaui4yvqp3f2bqwtxcjrdqg4")
+                .unwrap();
+        // short debug
+        assert_eq!(
+            &format!("{:?}", cid),
+            "Cid(bafyreibjo4xmgaevkgud7mbifn3dzp4v4lyaui4yvqp3f2bqwtxcjrdqg4)"
+        );
+        // verbose debug
+        let mut txt = format!("{:#?}", cid);
+        txt.retain(|c| !c.is_whitespace());
+        assert_eq!(&txt, "Cid{version:V1,codec:113,hash:Multihash{code:18,size:32,digest:[41,119,46,195,0,149,81,168,63,176,40,43,118,60,191,149,226,240,10,35,152,172,31,178,232,48,180,238,36,196,112,55,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,],},}");
+    }
 }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -25,7 +25,7 @@ const SHA2_256: u64 = 0x12;
 /// Representation of a CID.
 ///
 /// The generic is about the allocated size of the multihash.
-#[derive(PartialEq, Eq, Clone, Debug, PartialOrd, Ord, Hash)]
+#[derive(PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
 #[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
@@ -200,6 +200,25 @@ impl<S: Size> std::fmt::Display for Cid<S> {
             Version::V1 => self.to_string_v1(),
         };
         write!(f, "{}", output)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<S: Size> std::fmt::Debug for Cid<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if f.alternate() {
+            f.debug_struct("Cid")
+                .field("version", &self.version())
+                .field("codec", &self.codec())
+                .field("hash", self.hash())
+                .finish()
+        } else {
+            let output = match self.version {
+                Version::V0 => self.to_string_v0(),
+                Version::V1 => self.to_string_v1(),
+            };
+            write!(f, "Cid({})", output)
+        }
     }
 }
 


### PR DESCRIPTION
This will just output e.g. 

`Cid(bafyreibjo4xmgaevkgud7mbifn3dzp4v4lyaui4yvqp3f2bqwtxcjrdqg4)`
instead of very verbose and mostly useless debug output like

`Cid { version: V1, codec: 113, hash: Multihash { code: 18, size: 32, digest: [150, 149, 13, 62, 149, 26, 108, 78, 7, 248, 174, 227, 218, 106, 245, 219, 248, 11, 78, 15, 207, 37, 223, 220, 224, 186, 29, 161, 245, 213, 248, 64, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] } }`

The detailed debug output is still available using the alternate version, `{:#?}`

