### PR TITLE
.github/: Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
See https://dependabot.com/ for details on dependabot.

Part of the larger effort to switch rust-libp2p to upstream rust-multiaddr (https://github.com/libp2p/rust-libp2p/issues/758).