### PR TITLE
chore: Update example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,16 @@ Then run `cargo build`.
 ## Usage
 
 ```rust
-use cid::{Cid, Codec, Version};
-use multihash::Sha2_256;
+use cid::Cid;
+use multihash::{Code, MultihashDigest};
 use std::convert::TryFrom;
 
-fn main() {
-    let h = Sha2_256::digest(b"beep boop");
+const RAW: u64 = 0x55;
 
-    let cid = Cid::new(Version::V1, Codec::DagProtobuf, h).unwrap();
+fn main() {
+    let h = Code::Sha2_256.digest(b"beep boop");
+
+    let cid = Cid::new_v1(RAW, h);
 
     let data = cid.to_bytes();
     let out = Cid::try_from(data).unwrap();
@@ -52,7 +54,11 @@ fn main() {
     assert_eq!(cid, out);
 
     let cid_string = cid.to_string();
-    /// bafybeieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq
+    assert_eq!(
+        cid_string,
+        "bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq"
+    );
+    println!("{}", cid_string);
 }
 ```
 ## Maintainers

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 ## Usage
 
 ```rust
+use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
-use multihash::{Code, MultihashDigest};
 use std::convert::TryFrom;
 
 const RAW: u64 = 0x55;
@@ -55,7 +55,6 @@ Your `Cargo.toml` needs these dependencies:
 ```toml
 [dependencies]
 cid = "0.7.0"
-multihash = "0.14.0"
 ```
 
 You can also run this example from this checkout with `cargo run --example readme`.

--- a/README.md
+++ b/README.md
@@ -16,23 +16,11 @@
 
 ## Table of Contents
 
-- [Install](#install)
 - [Usage](#usage)
 - [Maintainers](#maintainers)
 - [Contribute](#contribute)
 - [License](#license)
 
-## Install
-
-First add this to your `Cargo.toml`
-
-```toml
-[dependencies]
-cid = "*"
-multihash = "0.10"
-```
-
-Then run `cargo build`.
 
 ## Usage
 
@@ -61,6 +49,17 @@ fn main() {
     println!("{}", cid_string);
 }
 ```
+
+Your `Cargo.toml` needs these dependencies:
+
+```toml
+[dependencies]
+cid = "0.7.0"
+multihash = "0.14.0"
+```
+
+You can also run this example from this checkout with `cargo run --example readme`.
+
 ## Maintainers
 
 Captain: [@dignifiedquire](https://github.com/dignifiedquire).

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,0 +1,23 @@
+use cid::Cid;
+use multihash::{Code, MultihashDigest};
+use std::convert::TryFrom;
+
+const RAW: u64 = 0x55;
+
+fn main() {
+    let h = Code::Sha2_256.digest(b"beep boop");
+
+    let cid = Cid::new_v1(RAW, h);
+
+    let data = cid.to_bytes();
+    let out = Cid::try_from(data).unwrap();
+
+    assert_eq!(cid, out);
+
+    let cid_string = cid.to_string();
+    assert_eq!(
+        cid_string,
+        "bafkreieq5jui4j25lacwomsqgjeswwl3y5zcdrresptwgmfylxo2depppq"
+    );
+    println!("{}", cid_string);
+}

--- a/examples/readme.rs
+++ b/examples/readme.rs
@@ -1,5 +1,5 @@
+use cid::multihash::{Code, MultihashDigest};
 use cid::Cid;
-use multihash::{Code, MultihashDigest};
 use std::convert::TryFrom;
 
 const RAW: u64 = 0x55;


### PR DESCRIPTION
Update the example in the README to work with the current version and
also add it as runnable example called `readme`:

    cargo run --example readme

Closes #78.