### PR TITLE
feat: custom Serde serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std"]
 alloc = ["multibase", "multihash/alloc"]
 arb = ["quickcheck", "rand", "multihash/arb"]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
-serde-codec = ["serde", "multihash/serde-codec"]
+serde-codec = ["serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
 multihash = { version = "0.15.0", default-features = false }
@@ -30,6 +30,7 @@ parity-scale-codec = { version = "2.1.1", default-features = false, features = [
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
 serde = { version = "1.0.116", optional = true }
+serde_bytes = { version = "0.11.5", optional = true }
 
 core2 = { version = "0.3", default-features = false, features = ["alloc"] }
 

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -64,8 +64,6 @@ const SHA2_256: u64 = 0x12;
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
 pub struct Cid<const S: usize> {
     /// The version of CID.
     version: Version,
@@ -363,17 +361,6 @@ mod tests {
         let cid = Cid::<64>::default();
         let bytes = cid.encode();
         let cid2 = Cid::decode(&mut &bytes[..]).unwrap();
-        assert_eq!(cid, cid2);
-    }
-
-    #[test]
-    #[cfg(feature = "serde-codec")]
-    fn test_cid_serde() {
-        use super::Cid;
-
-        let cid = Cid::<64>::default();
-        let bytes = serde_json::to_string(&cid).unwrap();
-        let cid2 = serde_json::from_str(&bytes).unwrap();
         assert_eq!(cid, cid2);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ mod version;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;
+#[cfg(feature = "serde-codec")]
+pub mod serde;
 
 pub use self::cid::Cid as CidGeneric;
 pub use self::error::{Error, Result};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -60,7 +60,6 @@ impl<'de> de::Visitor<'de> for CidVisitor {
     where
         E: de::Error,
     {
-        println!("vmx: visit bytes: value: {:?}", value);
         Cid::try_from(value)
             .map_err(|err| de::Error::custom(format!("Failed to deserialize CID: {}", err)))
     }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,92 @@
+//! CID Serde (de)serialization for the IPLD Data Model.
+//!
+//! CIDs cannot directly be represented in any of the native Serde Data model types. In order to
+//! work around that limitation. a newtype struct is introduced, that is used as a marker for Serde
+//! (de)serialization.
+use std::convert::TryFrom;
+use std::fmt;
+
+use serde::{de, ser};
+
+use crate::Cid;
+
+/// The newtype struct name that is used by Serde internally.
+pub const CID_SERDE_NEWTYPE_STRUCT_NAME: &str = "$__serde__newtype__struct__for__cid";
+
+impl ser::Serialize for Cid {
+    fn serialize<S>(&self, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: ser::Serializer,
+    {
+        let value = serde_bytes::ByteBuf::from(self.to_bytes());
+        s.serialize_newtype_struct(CID_SERDE_NEWTYPE_STRUCT_NAME, &value)
+    }
+}
+
+/// Visitor to deserialize a CID that is wrapped in a new type struct named as defined at
+/// [`CID_SERDE_NEWTYPE_STRUCT_NAME`].
+pub struct CidVisitor;
+
+impl<'de> de::Visitor<'de> for CidVisitor {
+    type Value = Cid;
+
+    fn expecting(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(fmt, "a valid CID in bytes, wrapped in a new struct")
+    }
+
+    /// Define `visit_newtype_struct` so that we have an entry-point from the seserializer to pass
+    /// in a custom deserializer just for CIDs.
+    fn visit_newtype_struct<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(self)
+    }
+
+    /// Some Serde data formats interpret a byte stream as a sequence of bytes (e.g. `serde_json`).
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: de::SeqAccess<'de>,
+    {
+        let mut bytes = Vec::new();
+        while let Some(byte) = seq.next_element()? {
+            bytes.push(byte);
+        }
+        Cid::try_from(bytes)
+            .map_err(|err| de::Error::custom(format!("Failed to deserialize CID: {}", err)))
+    }
+
+    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        println!("vmx: visit bytes: value: {:?}", value);
+        Cid::try_from(value)
+            .map_err(|err| de::Error::custom(format!("Failed to deserialize CID: {}", err)))
+    }
+}
+
+impl<'de> de::Deserialize<'de> for Cid {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        deserializer.deserialize_newtype_struct(CID_SERDE_NEWTYPE_STRUCT_NAME, CidVisitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use super::Cid;
+
+    #[test]
+    fn test_cid_serde() {
+        let cid =
+            Cid::try_from("bafkreibme22gw2h7y2h7tg2fhqotaqjucnbc24deqo72b6mkl2egezxhvy").unwrap();
+        let bytes = serde_json::to_string(&cid).unwrap();
+        let cid2 = serde_json::from_str(&bytes).unwrap();
+        assert_eq!(cid, cid2);
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -6,8 +6,6 @@ use crate::error::{Error, Result};
 #[derive(PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Debug, Hash)]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Decode))]
 #[cfg_attr(feature = "scale-codec", derive(parity_scale_codec::Encode))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Deserialize))]
-#[cfg_attr(feature = "serde-codec", derive(serde::Serialize))]
 pub enum Version {
     /// CID version 0.
     V0,


### PR DESCRIPTION
Instead of deriving a Serde serialization, implement it manually. The
serialized form is now equal to the binary representation of a CID.