### PR TITLE
fix: make serde-codec build with no_std

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,26 @@ jobs:
           command: build
           args: --no-default-features --target thumbv6m-none-eabi
 
+  build-no-std-serde:
+    name: Build no_std, but with `serde-codec` feature enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          # `thumbv6m-none-eabi` can't be used as Serde doesn't compile there.
+          args: --no-default-features --features serde-codec
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std"]
 alloc = ["multibase", "multihash/alloc"]
 arb = ["quickcheck", "rand", "multihash/arb"]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
-serde-codec = ["serde", "multihash/serde-codec", "serde_bytes"]
+serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
 multihash = { version = "0.16.1", default-features = false }
@@ -25,7 +25,7 @@ multibase = { version = "0.9.1", optional = true, default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
-serde = { version = "1.0.116", optional = true }
+serde = { version = "1.0.116", default-features = false, features = ["alloc"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 
 core2 = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -3,8 +3,11 @@
 //! CIDs cannot directly be represented in any of the native Serde Data model types. In order to
 //! work around that limitation. a newtype struct is introduced, that is used as a marker for Serde
 //! (de)serialization.
-use std::convert::TryFrom;
-use std::fmt;
+extern crate alloc;
+
+use alloc::{format, vec::Vec};
+use core::convert::TryFrom;
+use core::fmt;
 
 use serde::{de, ser};
 use serde_bytes::ByteBuf;


### PR DESCRIPTION
Prior to this change, enabling the `serde-codec` flag wouldn't build without `std`.