### PR TITLE
Only enable core2/alloc when alloc feature is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [features]
 default = ["std", "multihash/default"]
 std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std"]
-alloc = ["multibase", "multihash/alloc"]
+alloc = ["multibase", "multihash/alloc", "core2/alloc", "serde/alloc"]
 arb = ["quickcheck", "rand", "multihash/arb"]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
@@ -25,10 +25,10 @@ multibase = { version = "0.9.1", optional = true, default-features = false }
 parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
 quickcheck = { version = "0.9.2", optional = true }
 rand = { version = "0.7.3", optional = true }
-serde = { version = "1.0.116", default-features = false, features = ["alloc"], optional = true }
+serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 
-core2 = { version = "0.4", default-features = false, features = ["alloc"] }
+core2 = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.59"


### PR DESCRIPTION
This also moves the "alloc" feature of serde, but that doesn't really matter.

Unfortunately, I can't find a good way to _test_ this.