### PR TITLE
Restrict length of Multihash for new_v0

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -76,7 +76,7 @@ pub struct Cid<const S: usize> {
 impl<const S: usize> Cid<S> {
     /// Create a new CIDv0.
     pub const fn new_v0(hash: Multihash<S>) -> Result<Self> {
-        if hash.code() != SHA2_256 {
+        if hash.code() != SHA2_256 || hash.size() != 32 {
             return Err(Error::InvalidCidV0Multihash);
         }
         Ok(Self {

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -150,6 +150,22 @@ fn explicit_v0_is_disallowed() {
     ));
 }
 
+#[test]
+fn new_v0_accepts_only_32_bytes() {
+    use multihash::Multihash;
+    const SHA2_256: u64 = 0x12;
+
+    for i in 1..64 {
+        if i == 32 {
+            continue;
+        }
+        assert!(matches!(
+            Cid::new_v0(Multihash::wrap(SHA2_256, &vec![7; i]).unwrap()),
+            Err(Error::InvalidCidV0Multihash)
+        ));
+    }
+}
+
 fn a_function_that_takes_a_generic_cid<const S: usize>(cid: &CidGeneric<S>) -> String {
     cid.to_string()
 }


### PR DESCRIPTION
Not criticial but avoids possible correctness bugs.
Would have also cought the previous bug.