### PR TITLE
feat: add `encoded_len` and written bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
-multihash = { version = "0.17.0", default-features = false }
+multihash = { version = "0.18.0", default-features = false }
 unsigned-varint = { version = "0.7.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }
@@ -33,3 +33,4 @@ core2 = { version = "0.4", default-features = false }
 
 [dev-dependencies]
 serde_json = "1.0.59"
+


### PR DESCRIPTION
Depends on https://github.com/multiformats/rust-multihash/pull/252