### PR TITLE
chore: upgrade to Rust edition 2021 and set MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,12 @@ authors = ["Friedel Ziegelmayer <dignifiedquire@gmail.com>"]
 keywords = ["ipld", "ipfs", "cid", "multihash", "multiformats"]
 license = "MIT"
 readme = "README.md"
-edition = "2018"
+edition = "2021"
+rust-version = "1.60"
 
 [features]
 default = ["std", "multihash/default"]
-std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std"]
+std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std", "serde/std"]
 alloc = ["multibase", "multihash/alloc", "core2/alloc", "serde/alloc"]
 arb = ["quickcheck", "rand", "multihash/arb", "multihash/sha2", "arbitrary"]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -108,8 +108,6 @@ impl<'de, const SIZE: usize> de::Deserialize<'de> for CidGeneric<SIZE> {
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryFrom;
-
     use crate::CidGeneric;
 
     #[test]


### PR DESCRIPTION
The minimum supported Rust version is set to 1.60 due to the `parity-scale-codec` dependency.

BREAKING CHANGE: Rust edition 2021 is now used

---

As https://github.com/multiformats/rust-cid/pull/129 will be a breaking change, it makes sense to bundle them in one release, hence I propose doing a Rust edition 2021 upgrade here.