### PR TITLE
chore: add changelog for v0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# [v0.10.0](https://github.com/multiformats/rust-cid/compare/v0.9.0...v0.10.0) (2022-12-22)
+
+
+### chore
+
+* upgrade to Rust edition 2021 and set MSRV ([#130](https://github.com/multiformats/rust-cid/issues/130)) ([91fd35e](https://github.com/multiformats/rust-cid/commit/91fd35e06f8ae24d66f6ba4598830d8dbc259c8a))
+
+
+### Features
+
+* add `encoded_len` and written bytes ([#129](https://github.com/multiformats/rust-cid/issues/129)) ([715771c](https://github.com/multiformats/rust-cid/commit/715771c48fd47969e733ed1faad8b82d9ddbd7ca))
+
+
+### BREAKING CHANGES
+
+* Return `Result<usize>` (instead of `Result<()>`) now from `Cid::write_bytes`.
+* Rust edition 2021 is now used

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,48 @@
+Release process
+===============
+
+Generating Changelog
+--------------------
+
+Install dependencies
+
+```sh
+$ npm install -g conventional-changelog-cli
+$ cd rust-cid
+$ conventional-changelog --preset angular
+```
+
+Add the output of that to `CHANGELOG.md`, and write a human-centric summary of changes.
+Update the linked output to reference the new version, which conventional-changelog doesn't know about:
+
+```md
+# [](https://github.com/multiformats/rust-cid/compare/v0.9.0...v) (2022-12-22)
+```
+becomes:
+```md
+# [v0.10.0](https://github.com/multiformats/rust-cid/compare/v0.9.0...v0.10.0) (2022-12-22)
+```
+
+## Publishing
+
+Publishing on crates.io, bumping version & generating tags is done using [`cargo-release`](https://github.com/crate-ci/cargo-release).
+
+This requires the following permissions
+
+- on github.com/multiformats/rust-cid
+  - creating tags
+  - pushing to `master`
+- on crates.io
+  - publish access to all published crates
+
+Dry run
+
+```sh
+$ cargo release <patch|minor|major>
+```
+
+Actual publishing
+
+```sh
+$ cargo release --execute <patch|minor|major>
+```


### PR DESCRIPTION
This commit finally starts to add a changelog.

@Stebalien I know you hate breaking change releases (me too), this will hopefully be the last breaking one for a longer period of time. It's needed for https://github.com/ipld/libipld/pull/170.