### PR TITLE
Update multihash dependency to fix panic on some types of bad input

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
-multihash = { version = "0.18.0", default-features = false }
+multihash = { version = "0.18.1", default-features = false }
 unsigned-varint = { version = "0.7.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }


### PR DESCRIPTION
`multihash:0.18.0` can panic on some types of bad input. 
Require v0.18.1 in dependencies to avoid panics.

See the following pull request for more information:
https://github.com/multiformats/rust-multihash/pull/293