### PR TITLE
Add support for decoding V0 CIDs

### DIFF
--- a/src/cid.rs
+++ b/src/cid.rs
@@ -151,7 +151,12 @@ impl<const S: usize> Cid<S> {
 
         let version = Version::try_from(version)?;
         match version {
-            Version::V0 => Err(Error::InvalidExplicitCidV0),
+            Version::V0 => {
+                let mut buffer: Vec<u8> = Vec::new();
+                r.read_to_end(&mut buffer).unwrap();
+
+                Self::try_from(&buffer[1..])
+            }
             Version::V1 => {
                 let mh = Multihash::read(r)?;
                 Self::new(version, codec, mh)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -140,6 +140,23 @@ fn to_string_of_base_v0_error() {
 }
 
 #[test]
+fn can_decode_binary_v0_cid() {
+    use std::io::Cursor;
+
+    let expected_cid = "QmZEeJY1YBBdQsyu7H93QXrnjjin55TBw7B3SGkp8fwVsx";
+    let cid = Cid::read_bytes(Cursor::new([
+        0, 1, 113, 18, 32, 161, 230, 156, 160, 24, 32, 72, 189, 105, 55, 21, 161, 41, 2, 236, 199,
+        19, 90, 141, 186, 250, 97, 113, 25, 224, 90, 0, 55, 26, 187, 225, 235,
+    ]))
+    .unwrap();
+
+    assert_eq!(
+        cid.to_string_of_base(Base::Base58Btc).unwrap(),
+        expected_cid
+    );
+}
+
+#[test]
 fn new_v0_accepts_only_32_bytes() {
     use multihash::Multihash;
     const SHA2_256: u64 = 0x12;

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -140,17 +140,6 @@ fn to_string_of_base_v0_error() {
 }
 
 #[test]
-fn explicit_v0_is_disallowed() {
-    use std::io::Cursor;
-    assert!(matches!(
-        Cid::read_bytes(Cursor::new([
-            0x00, 0x70, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12, 0x12
-        ])),
-        Err(Error::InvalidExplicitCidV0)
-    ));
-}
-
-#[test]
 fn new_v0_accepts_only_32_bytes() {
     use multihash::Multihash;
     const SHA2_256: u64 = 0x12;


### PR DESCRIPTION
Many thanks for this excellent library!

In the course of trying to parse the [BlueSky](https://blueskyweb.xyz) firehose I discovered they use V0 CIDs in many places in the [AT Protocol sync specification](https://atproto.com/lexicons/com-atproto-sync).  Sadly, these V0 CIDs were not parseable with the current version of the library, but I think that is pretty easily supported with the following PR.
