### PR TITLE
feat: introduce Cid::const_new, which allows accessing Cids from const contexts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,35 @@ rust-version = "1.60"
 
 [features]
 default = ["std", "multihash/default"]
-std = ["multihash/std", "unsigned-varint/std", "alloc", "multibase/std", "serde/std"]
+std = [
+    "multihash/std",
+    "unsigned-varint/std",
+    "alloc",
+    "multibase/std",
+    "serde/std",
+]
 alloc = ["multibase", "multihash/alloc", "core2/alloc", "serde/alloc"]
-arb = ["quickcheck", "rand", "multihash/arb", "multihash/multihash-impl", "multihash/sha2", "arbitrary"]
+arb = [
+    "quickcheck",
+    "rand",
+    "multihash/arb",
+    # "multihash/multihash-impl",
+    # "multihash/sha2",
+    "arbitrary",
+]
 scale-codec = ["parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["alloc", "serde", "multihash/serde-codec", "serde_bytes"]
 
 [dependencies]
-multihash = { version = "0.18.0", default-features = false }
+multihash = { version = "0.19.0", default-features = false }
 unsigned-varint = { version = "0.7.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }
-parity-scale-codec = { version = "3.0.0", default-features = false, features = ["derive"], optional = true }
+parity-scale-codec = { version = "3.0.0", default-features = false, features = [
+    "derive",
+], optional = true }
 quickcheck = { version = "1.0", optional = true }
-rand = { version = "0.8.5", optional = true, features = ["small_rng"]}
+rand = { version = "0.8.5", optional = true, features = ["small_rng"] }
 serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 arbitrary = { version = "1.1.0", optional = true }
@@ -35,3 +50,5 @@ core2 = { version = "0.4", default-features = false }
 [dev-dependencies]
 serde_json = "1.0.59"
 
+[patch.crates-io]
+multihash = { git = "https://github.com/aatifsyed/rust-multihash.git" }


### PR DESCRIPTION
Resolves #138 

Blocked on:
- https://github.com/multiformats/rust-cid/pull/137
- Merge and release of https://github.com/multiformats/rust-multihash/pull/331
- Upgrade `rust-cid` to use the new release of the above 