### PR TITLE
test: don't require alloc for no_std test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,10 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
         shell: bash
 
+      - name: Test --no-default-features
+        run: cargo test --no-default-features
+        shell: bash
+
       - name: Test
         run: cargo test --all-features
         shell: bash

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -222,6 +222,6 @@ mod no_std_tests {
         // This should not panic, but should return an error.
         // bad_cid created during fuzz testing
         let bad_cid = [255, 255, 255, 255, 0, 6, 85, 0];
-        assert_eq!(Cid::read_bytes(&bad_cid[..]).is_ok(), false);
+        assert!(Cid::read_bytes(&bad_cid[..]).is_err());
     }
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-extern crate alloc;
+
 #[cfg(feature = "std")]
 mod std_tests {
     use std::collections::HashMap;
@@ -215,14 +215,13 @@ mod std_tests {
 
 #[cfg(all(test, not(feature = "std")))]
 mod no_std_tests {
-    use alloc::vec;
     use cid::Cid;
 
     #[test]
     fn validate_cid_unwrap_panics() {
         // This should not panic, but should return an error.
         // bad_cid created during fuzz testing
-        let bad_cid = vec![255, 255, 255, 255, 0, 6, 85, 0];
+        let bad_cid = [255, 255, 255, 255, 0, 6, 85, 0];
         assert_eq!(Cid::read_bytes(&bad_cid[..]).is_ok(), false);
     }
 }


### PR DESCRIPTION
Also run the no_std tests on CI.
