### PR TITLE
chore: prepare the v0.11.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# [v0.11.0](https://github.com/multiformats/rust-cid/compare/v0.10.1...v0.11.0) (2023-11-14)
+
+
+### Bug Fixes
+
+* `varint_read_u64` panics on unwrap in `no_std` environment ([#145](https://github.com/multiformats/rust-cid/issues/145)) ([86c7912](https://github.com/multiformats/rust-cid/commit/86c79126d851316350ad106d0df3e4ae69071874))
+* features accidentally pull in optional dependency ([#147](https://github.com/multiformats/rust-cid/issues/147)) ([942b70e](https://github.com/multiformats/rust-cid/commit/942b70ebd970b9c4a2f330a109227282e7596d29)), closes [#142](https://github.com/multiformats/rust-cid/issues/142)
+
+
+### Features
+
+* update to multihash 0.19 ([#140](https://github.com/multiformats/rust-cid/issues/140)) ([27b112d](https://github.com/multiformats/rust-cid/commit/27b112d2e6a8a1532f5a1c4ead2cc2e5a68b5dd5))
+
+
+### BREAKING CHANGES
+
+* Re-exported multihash changed. The multihash v0.19 release split it into several smaller crates, the `multihash` crate now has less functionality.
+
+
 # [v0.10.1](https://github.com/multiformats/rust-cid/compare/v0.10.0...v0.10.1) (2023-01-09)
 
 


### PR DESCRIPTION
Update the changelog.

---

As this is a breaking change (due to upgrading multihash), this is the chance to comment if someone wants more breaking changes in. Once this PR is merged, I'll cut a release.