### PR TITLE
fix: wrong serde-codec feature gate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ mod version;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;
-#[cfg(feature = "serde-codec")]
+#[cfg(feature = "serde")]
 pub mod serde;
 
 pub use self::cid::Cid as CidGeneric;


### PR DESCRIPTION
The `serde-codec` feature was renamed to `serde`, which is now the preferred name. When `serde-codec` is enabled, it also automatically enables the `serde` feature. Hence feature gate the Serde implementation with the `serde` feature.