### PR TITLE
Replace homepage attribute with repository in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cid"
 version = "0.11.1"
 description = "CID in rust"
-homepage = "https://github.com/multiformats/rust-cid"
+repository = "https://github.com/multiformats/rust-cid"
 authors = ["Friedel Ziegelmayer <dignifiedquire@gmail.com>"]
 keywords = ["ipld", "ipfs", "cid", "multihash", "multiformats"]
 license = "MIT"


### PR DESCRIPTION
Hi! While scraping crates.io I've found this crate to be missing the `repository` attribute in Cargo.toml. This attribute makes it easy for users and scrapers, including security tools, to find about the repository behind a crate. I've decided to replace the `homepage` attribute with `repository` as that is the more common choice among crates.