### PR TITLE
feat: add compat featues for converting Cid between versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [v0.11.2]
+
+* add `compat_0_9` and `compat_0_10` features under which `TryFrom` trait is implemented for converting `Cid` between versions.
+
 # [v0.11.1](https://github.com/multiformats/rust-cid/compare/v0.11.0...v0.11.1) (2024-03-01)
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cid"
-version = "0.11.1"
+version = "0.11.2"
 description = "CID in rust"
 repository = "https://github.com/multiformats/rust-cid"
 authors = ["Friedel Ziegelmayer <dignifiedquire@gmail.com>"]
@@ -14,10 +14,12 @@ rust-version = "1.60"
 default = ["std"]
 std = ["alloc", "core2/alloc", "multihash/std", "unsigned-varint/std"]
 alloc = ["dep:multibase", "core2/alloc", "multihash/alloc"]
-arb = ["dep:arbitrary", "dep:quickcheck", "dep:rand", "multihash/arb"]
+arb = ["dep:arbitrary", "dep:quickcheck", "dep:rand", "multihash/arb", "cid_0_9?/arb", "cid_0_10?/arb"]
 scale-codec = ["dep:parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
 serde = ["alloc", "dep:serde", "dep:serde_bytes", "multihash/serde"]
+compat_0_9 = ["std", "dep:cid_0_9"]
+compat_0_10 = ["std", "dep:cid_0_10"]
 
 [dependencies]
 multihash = { version = "0.19.0", default-features = false }
@@ -30,6 +32,8 @@ rand = { version = "0.8.5", optional = true, features = ["small_rng"]}
 serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 arbitrary = { version = "1.1.0", optional = true }
+cid_0_9 = { package = "cid", version = "0.9", optional = true }
+cid_0_10 = { package = "cid", version = "0.10", optional = true }
 
 core2 = { version = "0.4", default-features = false }
 
@@ -37,3 +41,4 @@ core2 = { version = "0.4", default-features = false }
 multihash-derive = { version = "0.9.0", default-features = false }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"]}
 multihash-codetable = { version = "0.1.0", default-features = false, features = ["digest", "sha2"] }
+quickcheck_macros = { version = "1.0" }

--- a/src/compat_0_10.rs
+++ b/src/compat_0_10.rs
@@ -1,0 +1,37 @@
+//! This module implements [`TryFrom`] trait for converting between [`crate::Cid`]
+//! and [`cid_0_10::Cid`]
+
+impl TryFrom<crate::Cid> for cid_0_10::Cid {
+    type Error = cid_0_10::Error;
+
+    fn try_from(value: crate::Cid) -> Result<Self, Self::Error> {
+        let bytes = value.to_bytes();
+        Self::read_bytes(bytes.as_slice())
+    }
+}
+
+impl TryFrom<cid_0_10::Cid> for crate::Cid {
+    type Error = crate::Error;
+
+    fn try_from(value: cid_0_10::Cid) -> Result<Self, Self::Error> {
+        let bytes = value.to_bytes();
+        Self::read_bytes(bytes.as_slice())
+    }
+}
+
+#[cfg(all(test, feature = "arb"))]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    #[quickcheck]
+    fn to_old_cid(cid: crate::Cid) {
+        let other: cid_0_10::Cid = cid.try_into().unwrap();
+        assert_eq!(cid.to_bytes(), other.to_bytes());
+    }
+
+    #[quickcheck]
+    fn from_old_cid(cid: cid_0_10::Cid) {
+        let other: crate::Cid = cid.try_into().unwrap();
+        assert_eq!(cid.to_bytes(), other.to_bytes());
+    }
+}

--- a/src/compat_0_9.rs
+++ b/src/compat_0_9.rs
@@ -1,0 +1,37 @@
+//! This module implements [`TryFrom`] trait for converting between [`crate::Cid`]
+//! and [`cid_0_9::Cid`]
+
+impl TryFrom<crate::Cid> for cid_0_9::Cid {
+    type Error = cid_0_9::Error;
+
+    fn try_from(value: crate::Cid) -> Result<Self, Self::Error> {
+        let bytes = value.to_bytes();
+        Self::read_bytes(bytes.as_slice())
+    }
+}
+
+impl TryFrom<cid_0_9::Cid> for crate::Cid {
+    type Error = crate::Error;
+
+    fn try_from(value: cid_0_9::Cid) -> Result<Self, Self::Error> {
+        let bytes = value.to_bytes();
+        Self::read_bytes(bytes.as_slice())
+    }
+}
+
+#[cfg(all(test, feature = "arb"))]
+mod tests {
+    use quickcheck_macros::quickcheck;
+
+    #[quickcheck]
+    fn to_old_cid(cid: crate::Cid) {
+        let other: cid_0_9::Cid = cid.try_into().unwrap();
+        assert_eq!(cid.to_bytes(), other.to_bytes());
+    }
+
+    #[quickcheck]
+    fn from_old_cid(cid: cid_0_9::Cid) {
+        let other: crate::Cid = cid.try_into().unwrap();
+        assert_eq!(cid.to_bytes(), other.to_bytes());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod cid;
+#[cfg(feature = "compat_0_10")]
+mod compat_0_10;
+#[cfg(feature = "compat_0_9")]
+mod compat_0_9;
 mod error;
 mod version;
 


### PR DESCRIPTION
This PR proposes 2 new `compat_0_9` and `compat_0_10` features under which `TryFrom` trait is implemented for converting `Cid` between versions. 

Problem to solve: when upgrading `cid`, there is a pain point that some other crates in the dependency tree may still depend on an old version of  `cid`. Implementing `TryFrom` makes it much easier to convert between different versions of `Cid`