### PR TITLE
chore: bump msrv to 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["ipld", "ipfs", "cid", "multihash", "multiformats"]
 license = "MIT"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
To fix https://github.com/multiformats/rust-cid/actions/runs/11854518907/job/33036842910?pr=164#step:6:142

```
warning: current MSRV (Minimum Supported Rust Version) is `1.60.0` but this item is stable since `1.63.0`
  --> src/arb.rs:26:24
   |
26 |             let data = core::array::from_fn::<_, 32, _>(|_| u8::arbitrary(g));
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
   = note: `#[warn(clippy::incompatible_msrv)]` on by default

```