### PR TITLE
Update MSRV to 1.81, specify toolchain, and fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,6 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
-        toolchain: [stable]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -21,12 +20,6 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: rustfmt, clippy
 
       - name: Check Code Format
         run: cargo fmt --all -- --check
@@ -52,27 +45,23 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: thumbv6m-none-eabi
+        run: rustup target add thumbv6m-none-eabi
+        shell: bash
 
       - name: Build
         run: cargo build --no-default-features --target thumbv6m-none-eabi
         shell: bash
 
   build-no-std-serde:
-    name: Build no_std, but with `serde-codec` feature enabled
+    name: Build no_std, but with `serde` feature enabled
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
 
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Build
         # `thumbv6m-none-eabi` can't be used as Serde doesn't compile there.
-        run: cargo build --no-default-features --features serde-codec
+        run: cargo build --no-default-features --features serde
         shell: bash
 
   coverage:
@@ -81,9 +70,6 @@ jobs:
     steps:
       - name: Checkout Sources
         uses: actions/checkout@v4
-
-      - name: Install Rust Toolchain
-        uses: dtolnay/rust-toolchain@stable
 
       - name: Generate Code Coverage
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = ["ipld", "ipfs", "cid", "multihash", "multiformats"]
 license = "MIT"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.63"
+rust-version = "1.81"
 
 [features]
 default = ["std"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.81.0"
 components = ["clippy", "llvm-tools-preview", "rustfmt"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.63.0"
+components = ["clippy", "llvm-tools-preview", "rustfmt"]


### PR DESCRIPTION
1. Test on the MSRV.
2. Use `rust-toolchain.toml` to specify the default compiler.
3. Update the MSRV to 1.81 to match our dependencies.