### PR TITLE
doc: don't document crate version in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,7 @@ fn main() {
 }
 ```
 
-Your `Cargo.toml` needs these dependencies:
-
-```toml
-[dependencies]
-cid = "0.7.0"
-```
-
-You can also run this example from this checkout with `cargo run --example readme`.
+You can use this package by adding it to your `Cargo.toml` with `cargo add cid`.
 
 ## Testing
 


### PR DESCRIPTION
We always forget to update it. Instead, document how to add the dependency with `cargo add`.

Also, remove the documentation around how to test the README example, it no longer works and the README is now tested as a part of the main test suite.