### PR TITLE
fix: remove default features of serde_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ parity-scale-codec = { version = "3.0.0", default-features = false, features = [
 quickcheck = { version = "1.0", optional = true }
 rand = { version = "0.8.5", optional = true, features = ["small_rng"]}
 serde = { version = "1.0.116", default-features = false, optional = true }
-serde_bytes = { version = "0.11.5", optional = true }
+serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc"], optional = true }
 arbitrary = { version = "1.1.0", optional = true }
 
 core2 = { version = "0.4", default-features = false }


### PR DESCRIPTION
serde_bytes with default features makes it not possible to use the library in a no_std context with the serde feature.

ex: `cargo build --no-default-features --target=riscv32imc-unknown-none-elf --features=serde`