### PR TITLE
Replace archived core2 dependency with no_std_io2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde-codec = ["serde"] # Deprecated, don't use.
 serde = ["alloc", "dep:serde", "dep:serde_bytes", "multihash/serde"]
 
 [dependencies]
-multihash = { version = "0.19.0", default-features = false }
+multihash = { version = "0.19.4", default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }
@@ -34,7 +34,6 @@ arbitrary = { version = "1.1.0", optional = true }
 no_std_io2 = { version = "0.8.1", default-features = false }
 
 [dev-dependencies]
-multihash-derive = { version = "0.9.0", default-features = false }
+multihash-derive = { version = "0.9.2", default-features = false }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"]}
-multihash-codetable = { version = "0.1.0", default-features = false, features = ["sha2"] }
-
+multihash-codetable = { version = "0.2.1", default-features = false, features = ["sha2"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.81"
 
 [features]
 default = ["std"]
-std = ["alloc", "core2/alloc", "multihash/std", "unsigned-varint/std"]
-alloc = ["dep:multibase", "core2/alloc", "multihash/alloc"]
+std = ["alloc", "no_std_io2/alloc", "multihash/std", "unsigned-varint/std"]
+alloc = ["dep:multibase", "no_std_io2/alloc", "multihash/alloc"]
 arb = ["dep:arbitrary", "dep:quickcheck", "dep:rand", "multihash/arb"]
 scale-codec = ["dep:parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
@@ -31,9 +31,10 @@ serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc"], optional = true }
 arbitrary = { version = "1.1.0", optional = true }
 
-core2 = { version = "0.4", default-features = false }
+no_std_io2 = { version = "0.8.1", default-features = false }
 
 [dev-dependencies]
 multihash-derive = { version = "0.9.0", default-features = false }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"]}
 multihash-codetable = { version = "0.1.0", default-features = false, features = ["sha2"] }
+

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -51,7 +51,7 @@ pub(crate) fn varint_read_u64<R: io::Read>(mut r: R) -> Result<u64> {
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use core2::io;
+use no_std_io2::io;
 
 use crate::error::{Error, Result};
 use crate::version::Version;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use core2::io;
+use no_std_io2::io;
 
 /// Type alias to use this library's [`Error`] type in a `Result`.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
## Summary

`core2` was [archived upstream on 2026-04-14](https://github.com/bbqsrc/core2) with the note "No longer supported. Use `core` directly." Version 0.4.0 is yanked from crates.io with no replacement, making `cid` currently unbuildable from a clean checkout against the default registry.

This PR swaps `core2` for [`no_std_io2`](https://crates.io/crates/no_std_io2), an API-compatible drop-in replacement purpose-built for crates that need `std::io`'s trait shape in `no_std` contexts.

## Approach

Mirrors the approach in [multiformats/rust-multihash#407](https://github.com/multiformats/rust-multihash/pull/407) for multiformats org consistency. The diff is the minimum needed:

- `Cargo.toml`: replace the `core2` dependency with `no_std_io2 = "0.8.1"`; update two feature flags (`std`, `alloc`) to reference `no_std_io2/alloc` instead of `core2/alloc`.
- `src/cid.rs`, `src/error.rs`: replace the two `use core2::io;` imports with `use no_std_io2::io;`.

No other changes. `no_std_io2`'s `io::Read` and `io::Error` types preserve the exact surface previously consumed from `core2::io`.

## Alternatives considered

- **`core::io::{Read, Write}`**: not stable ([rust-lang/rust#68315](https://github.com/rust-lang/rust/issues/68315) has been open since 2020, blocked on the `std::io::Error` OS-coupling problem).
- **`embedded-io`**: more idiomatic for new work, but introduces a different trait surface and would be a larger, more opinionated change. Happy to rework as `embedded-io` if maintainers prefer.
- **Vendored internal shim**: minimal diff but leaves the org inconsistent with the `rust-multihash` migration.

## Testing

Currently, `cid`'s own dev-dependency chain (`multihash-codetable`) pulls `core2` transitively, so the upstream test suite can't build against a clean registry until [#407](https://github.com/multiformats/rust-multihash/pull/407) merges and a release is cut. Once that lands, the test suite unblocks automatically.

The library itself compiles cleanly against `no_std_io2` for `--all-features`, `--no-default-features`, and `--no-default-features --features alloc`.

## Refs

Closes #184.