### PR TITLE
remove `no_std_io2` from dep tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,23 @@ jobs:
         run: cargo build --no-default-features --target thumbv6m-none-eabi
         shell: bash
 
+  build-no-std-with-alloc:
+    name: Build no_std, but with `alloc` feature enabled
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Sources
+        uses: actions/checkout@v6
+
+      - name: Install Rust Toolchain
+        run: rustup target add thumbv6m-none-eabi
+        shell: bash
+
+      - name: Build
+        # thumbv6m-none-eabi is a platform that doesn't have any std librarry.
+        # It's often used to make sure that std isn't enabled accidentally.
+        run: cargo build --no-default-features --features alloc --target thumbv6m-none-eabi
+        shell: bash
+
   build-no-std-with-serde:
     name: Build no_std, but with `serde` feature enabled
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ rust-version = "1.81"
 
 [features]
 default = ["std"]
-std = ["alloc", "no_std_io2/alloc", "multihash/std", "unsigned-varint/std"]
-alloc = ["dep:multibase", "no_std_io2/alloc", "multihash/alloc"]
+std = ["alloc", "multihash/std", "unsigned-varint/std"]
+alloc = ["dep:multibase", "multihash/alloc"]
 arb = ["dep:arbitrary", "dep:quickcheck", "dep:rand", "multihash/arb"]
 scale-codec = ["dep:parity-scale-codec", "multihash/scale-codec"]
 serde-codec = ["serde"] # Deprecated, don't use.
@@ -31,9 +31,13 @@ serde = { version = "1.0.116", default-features = false, optional = true }
 serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc"], optional = true }
 arbitrary = { version = "1.1.0", optional = true }
 
-no_std_io2 = { version = "0.8.1", default-features = false }
-
 [dev-dependencies]
 multihash-derive = { version = "0.9.2", default-features = false }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"]}
 multihash-codetable = { version = "0.2.1", default-features = false, features = ["sha2"] }
+
+# For testing, remove before moving PR out of draft.
+[patch.crates-io]
+multihash = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }
+multihash-derive = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }
+multihash-codetable = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde-codec = ["serde"] # Deprecated, don't use.
 serde = ["alloc", "dep:serde", "dep:serde_bytes", "multihash/serde"]
 
 [dependencies]
-multihash = { version = "0.19.4", default-features = false }
+multihash = { version = "0.19.5", default-features = false }
 unsigned-varint = { version = "0.8.0", default-features = false }
 
 multibase = { version = "0.9.1", optional = true, default-features = false }
@@ -32,12 +32,6 @@ serde_bytes = { version = "0.11.5", default-features = false, features = ["alloc
 arbitrary = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
-multihash-derive = { version = "0.9.2", default-features = false }
+multihash-derive = { version = "0.9.3", default-features = false }
 serde_json = { version = "1.0.59", default-features = false, features = ["alloc"]}
-multihash-codetable = { version = "0.2.1", default-features = false, features = ["sha2"] }
-
-# For testing, remove before moving PR out of draft.
-[patch.crates-io]
-multihash = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }
-multihash-derive = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }
-multihash-codetable = { git = "https://github.com/hanabi1224/rust-multihash.git", branch = "embed-nostd-io" }
+multihash-codetable = { version = "0.2.2", default-features = false, features = ["sha2"] }

--- a/src/cid.rs
+++ b/src/cid.rs
@@ -51,7 +51,7 @@ pub(crate) fn varint_read_u64<R: io::Read>(mut r: R) -> Result<u64> {
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use no_std_io2::io;
+use multihash::no_std_io as io;
 
 use crate::error::{Error, Result};
 use crate::version::Version;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@ use core::fmt;
 use std::io;
 
 #[cfg(not(feature = "std"))]
-use no_std_io2::io;
+use multihash::no_std_io as io;
 
 /// Type alias to use this library's [`Error`] type in a `Result`.
 pub type Result<T> = core::result::Result<T, Error>;


### PR DESCRIPTION
To work with https://github.com/multiformats/rust-multihash/pull/411 It should require a minor version bump